### PR TITLE
Add task to run the WordPress database update procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add task to run the WordPress database update procedure on deployment.
+
 ### Changed
 - Set `keep_releases` option `3` by default.
 

--- a/res/deploy.tpl.php
+++ b/res/deploy.tpl.php
@@ -79,7 +79,7 @@ task(
 	}
 );
 
-desc( 'Runs the WordPress database update procedure.' );
+desc( 'Runs the WordPress database update procedure' );
 task(
 	'wp:upgrade_db',
 	function () {

--- a/res/deploy.tpl.php
+++ b/res/deploy.tpl.php
@@ -79,6 +79,20 @@ task(
 	}
 );
 
+desc( 'Runs the WordPress database update procedure.' );
+task(
+	'wp:upgrade_db',
+	function () {
+		within(
+			'{{release_path}}',
+			function () {
+				$is_multisite = test( 'wp core is-installed --network' );
+				run( 'wp core update-db' . ( $is_multisite ? ' --network' : '' ) );
+			}
+		);
+	}
+);
+
 desc( 'Deploy your project' );
 task(
 	'deploy',
@@ -95,6 +109,7 @@ task(
 		'deploy:clear_paths',
 		'deploy:symlink',
 		'wp:opcache_clear',
+		'wp:upgrade_db',
 		'deploy:unlock',
 		'cleanup',
 		'success',


### PR DESCRIPTION
Fixes https://github.com/wearerequired/composer-deployer/issues/9.