### PR TITLE
Introduce `wp:post_rollout` task to run custom WP-CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Add `wp:post_rollout` task and `post_rollout_wp_cli_commands` option to run custom WP-CLI commands before finishing the deployment.
+
 ## [0.5.0] - 2021-11-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-* Add `wp:post_rollout` task and `post_rollout_wp_cli_commands` option to run custom WP-CLI commands before finishing the deployment.
+* Add `wp:post_rollout` task and `post_rollout_commands` option to run custom commands before finishing the deployment.
 
 ## [0.5.0] - 2021-11-02
 

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ composer require wearerequired/composer-deployer
 * Installs and updates WordPress translations via WP-CLI if `wp_languages` option is set.
 * Clears OPcache via WP-CLI (requires [WP-CLI Clear OPcache](https://github.com/wearerequired/wp-cli-clear-opcache)). Can be disabled via `wp_clear_opcache` option.
 * Runs WordPress database routine if `wordpress` option is set.
+* Run custom commands via `post_rollout_commands` option before the deployment is finished.

--- a/res/deploy.tpl.php
+++ b/res/deploy.tpl.php
@@ -149,15 +149,15 @@ task(
 	}
 );
 
-desc( 'Run WP-CLI commands before finishing the deployment' );
+desc( 'Run commands before finishing the deployment' );
 task(
 	'wp:post_rollout',
 	function (): void {
-		if ( ! get( 'wordpress' ) || ! has( 'post_rollout_wp_cli_commands' ) ) {
+		if ( ! has( 'post_rollout_commands' ) ) {
 			return;
 		}
 
-		$commands = get( 'post_rollout_wp_cli_commands' );
+		$commands = get( 'post_rollout_commands' );
 		if ( ! \is_array( $commands ) ) {
 			$commands = [ $commands ];
 		}
@@ -166,7 +166,7 @@ task(
 			'{{release_path}}',
 			function () use ( $commands ): void {
 				foreach ( $commands as $command ) {
-					run( "{{bin/wp}} {$command}" );
+					run( $command );
 				}
 			}
 		);

--- a/res/deploy.tpl.php
+++ b/res/deploy.tpl.php
@@ -149,6 +149,30 @@ task(
 	}
 );
 
+desc( 'Run WP-CLI commands before finishing the deployment' );
+task(
+	'wp:post_rollout',
+	function (): void {
+		if ( ! get( 'wordpress' ) || ! has( 'post_rollout_wp_cli_commands' ) ) {
+			return;
+		}
+
+		$commands = get( 'post_rollout_wp_cli_commands' );
+		if ( ! \is_array( $commands ) ) {
+			$commands = [ $commands ];
+		}
+
+		within(
+			'{{release_path}}',
+			function () use ( $commands ): void {
+				foreach ( $commands as $command ) {
+					run( "{{bin/wp}} {$command}" );
+				}
+			}
+		);
+	}
+);
+
 desc( 'Deploy your project' );
 task(
 	'deploy',
@@ -167,6 +191,7 @@ task(
 		'deploy:symlink',
 		'wp:opcache_clear',
 		'wp:upgrade_db',
+		'wp:post_rollout',
 		'deploy:unlock',
 		'cleanup',
 		'success',


### PR DESCRIPTION
This PR introduces a `wp:post_rollout` task to be able to run project specific WP-CLI commands. The commands can be set via deploy.yml and the `post_rollout_wp_cli_commands`

Example config:

```yml
.base: &base
  // …
  post_rollout_commands:
    - "{{bin/wp}} kinsta cache purge || true"
```