### PR TITLE
Support multiple production/testing branches in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,29 @@ on:
         description: Relative path under $GITHUB_WORKSPACE to place the project repository.
         type: string
         default: ./project-repository
+      production_branches:
+        description: |
+          Newline-separated list of branches that map to a production environment.
+          Each listed branch is expected to match a Deployer host alias in `deploy.yml`.
+          Defaults to `production` for backwards compatibility.
+        type: string
+        default: production
+      testing_branches:
+        description: |
+          Newline-separated list of branches that map to a testing environment.
+          Each listed branch is expected to match a Deployer host alias in `deploy.yml`.
+          Defaults to `testing` for backwards compatibility.
+        type: string
+        default: testing
+      environment_urls:
+        description: |
+          Optional newline-separated `branch=url` pairs that override the deployment URL
+          for a given branch. If not set, falls back to `secrets.ENVIRONMENT_URL_PRODUCTION`,
+          `secrets.ENVIRONMENT_URL_TESTING`, or `secrets.ENVIRONMENT_URL` based on the
+          resolved environment (legacy behaviour). Values may reference secrets in the
+          caller workflow, e.g. `production-sg=${{ secrets.ENVIRONMENT_URL_PRODUCTION_SG }}`.
+        type: string
+        default: ''
 
 env:
   ENVIRONMENT_URL: ${{ secrets.ENVIRONMENT_URL }}
@@ -34,6 +57,13 @@ jobs:
 
     steps:
       - name: Set custom environment variables
+        env:
+          INPUT_PRODUCTION_BRANCHES: ${{ inputs.production_branches }}
+          INPUT_TESTING_BRANCHES: ${{ inputs.testing_branches }}
+          INPUT_ENVIRONMENT_URLS: ${{ inputs.environment_urls }}
+          SECRET_ENVIRONMENT_URL: ${{ secrets.ENVIRONMENT_URL }}
+          SECRET_ENVIRONMENT_URL_PRODUCTION: ${{ secrets.ENVIRONMENT_URL_PRODUCTION }}
+          SECRET_ENVIRONMENT_URL_TESTING: ${{ secrets.ENVIRONMENT_URL_TESTING }}
         run: |
           TIMESTAMP=$(date +'%s')
           BRANCH=${GITHUB_REF#refs/heads/}
@@ -41,17 +71,60 @@ jobs:
           CHECK_SUITE_URL=$(curl -s -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} | jq -r '.check_suite_url')
           CHECK_RUN_ID=$(curl -s -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.antiope-preview+json" $CHECK_SUITE_URL/check-runs | jq '.check_runs[] | select(.name|test("\/ Deploy$")) | .id ')
 
+          # Resolve target environment from configured branch lists.
+          # For branches listed in production_branches / testing_branches the
+          # branch name itself is used as Deployer selector (`dep deploy <branch>`).
+          # Everything else falls back to the staging tier (`stage=staging`).
+          ENVIRONMENT=staging
+          DEPLOYER_SELECTOR="stage=staging"
+
+          while IFS= read -r prod_branch; do
+            prod_branch=$(echo "$prod_branch" | xargs)
+            [ -z "$prod_branch" ] && continue
+            if [ "$BRANCH" = "$prod_branch" ]; then
+              ENVIRONMENT=production
+              DEPLOYER_SELECTOR="$BRANCH"
+              break
+            fi
+          done <<< "$INPUT_PRODUCTION_BRANCHES"
+
+          if [ "$ENVIRONMENT" = "staging" ]; then
+            while IFS= read -r test_branch; do
+              test_branch=$(echo "$test_branch" | xargs)
+              [ -z "$test_branch" ] && continue
+              if [ "$BRANCH" = "$test_branch" ]; then
+                ENVIRONMENT=testing
+                DEPLOYER_SELECTOR="$BRANCH"
+                break
+              fi
+            done <<< "$INPUT_TESTING_BRANCHES"
+          fi
+
+          # Resolve environment URL (default by tier, optional per-branch override).
+          case "$ENVIRONMENT" in
+            production) ENVIRONMENT_URL="$SECRET_ENVIRONMENT_URL_PRODUCTION" ;;
+            testing)    ENVIRONMENT_URL="$SECRET_ENVIRONMENT_URL_TESTING" ;;
+            *)          ENVIRONMENT_URL="$SECRET_ENVIRONMENT_URL" ;;
+          esac
+
+          while IFS= read -r line; do
+            line=$(echo "$line" | xargs)
+            [ -z "$line" ] && continue
+            key="${line%%=*}"
+            val="${line#*=}"
+            if [ "$key" = "$BRANCH" ]; then
+              ENVIRONMENT_URL="$val"
+              break
+            fi
+          done <<< "$INPUT_ENVIRONMENT_URLS"
+
           echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
           echo "SHA_SHORT=$SHA_SHORT" >> $GITHUB_ENV
           echo "CHECK_RUN_ID=$CHECK_RUN_ID" >> $GITHUB_ENV
-          if [ "$BRANCH" == "production" ]; then
-            echo "ENVIRONMENT=production" >> $GITHUB_ENV
-            echo "ENVIRONMENT_URL=${{ secrets.ENVIRONMENT_URL_PRODUCTION }}" >> $GITHUB_ENV
-          elif [ "$BRANCH" == "testing" ]; then
-              echo "ENVIRONMENT=testing" >> $GITHUB_ENV
-              echo "ENVIRONMENT_URL=${{ secrets.ENVIRONMENT_URL_TESTING }}" >> $GITHUB_ENV
-          fi;
+          echo "ENVIRONMENT=$ENVIRONMENT" >> $GITHUB_ENV
+          echo "ENVIRONMENT_URL=$ENVIRONMENT_URL" >> $GITHUB_ENV
+          echo "DEPLOYER_SELECTOR=$DEPLOYER_SELECTOR" >> $GITHUB_ENV
 
       - name: Send init Slack notification
         id: slack
@@ -174,9 +247,9 @@ jobs:
         working-directory: ${{ inputs.project_working_directory }}
         run: |
           if [ -n "${RUNNER_DEBUG+1}" ]; then
-            dep deploy stage=$ENVIRONMENT --branch $BRANCH --no-interaction -vvv
+            dep deploy "$DEPLOYER_SELECTOR" --no-interaction -vvv
           else
-            dep deploy stage=$ENVIRONMENT --branch $BRANCH --no-interaction
+            dep deploy "$DEPLOYER_SELECTOR" --no-interaction
           fi
 
       - name: Unlock Deployer
@@ -185,9 +258,9 @@ jobs:
         run: |
           if hash dep 2>/dev/null; then
             if [ -n "${RUNNER_DEBUG+1}" ]; then
-              dep deploy:unlock stage=$ENVIRONMENT --no-interaction -vvv
+              dep deploy:unlock "$DEPLOYER_SELECTOR" --no-interaction -vvv
             else
-              dep deploy:unlock stage=$ENVIRONMENT --no-interaction
+              dep deploy:unlock "$DEPLOYER_SELECTOR" --no-interaction
             fi
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ on:
         default: ''
 
 env:
-  ENVIRONMENT_URL: ${{ secrets.ENVIRONMENT_URL }}
+  ENVIRONMENT_URL: ${{ vars.ENVIRONMENT_URL || secrets.ENVIRONMENT_URL }}
   ENVIRONMENT: staging
 
 jobs:
@@ -61,6 +61,9 @@ jobs:
           INPUT_PRODUCTION_BRANCHES: ${{ inputs.production_branches }}
           INPUT_TESTING_BRANCHES: ${{ inputs.testing_branches }}
           INPUT_ENVIRONMENT_URLS: ${{ inputs.environment_urls }}
+          VAR_ENVIRONMENT_URL: ${{ vars.ENVIRONMENT_URL }}
+          VAR_ENVIRONMENT_URL_PRODUCTION: ${{ vars.ENVIRONMENT_URL_PRODUCTION }}
+          VAR_ENVIRONMENT_URL_TESTING: ${{ vars.ENVIRONMENT_URL_TESTING }}
           SECRET_ENVIRONMENT_URL: ${{ secrets.ENVIRONMENT_URL }}
           SECRET_ENVIRONMENT_URL_PRODUCTION: ${{ secrets.ENVIRONMENT_URL_PRODUCTION }}
           SECRET_ENVIRONMENT_URL_TESTING: ${{ secrets.ENVIRONMENT_URL_TESTING }}
@@ -100,11 +103,11 @@ jobs:
             done <<< "$INPUT_TESTING_BRANCHES"
           fi
 
-          # Resolve environment URL (default by tier, optional per-branch override).
+          # Resolve environment URL: per-branch override > repo variable > secret.
           case "$ENVIRONMENT" in
-            production) ENVIRONMENT_URL="$SECRET_ENVIRONMENT_URL_PRODUCTION" ;;
-            testing)    ENVIRONMENT_URL="$SECRET_ENVIRONMENT_URL_TESTING" ;;
-            *)          ENVIRONMENT_URL="$SECRET_ENVIRONMENT_URL" ;;
+            production) ENVIRONMENT_URL="${VAR_ENVIRONMENT_URL_PRODUCTION:-$SECRET_ENVIRONMENT_URL_PRODUCTION}" ;;
+            testing)    ENVIRONMENT_URL="${VAR_ENVIRONMENT_URL_TESTING:-$SECRET_ENVIRONMENT_URL_TESTING}" ;;
+            *)          ENVIRONMENT_URL="${VAR_ENVIRONMENT_URL:-$SECRET_ENVIRONMENT_URL}" ;;
           esac
 
           while IFS= read -r line; do

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,10 +33,12 @@ on:
       environment_urls:
         description: |
           Optional newline-separated `branch=url` pairs that override the deployment URL
-          for a given branch. If not set, falls back to `secrets.ENVIRONMENT_URL_PRODUCTION`,
-          `secrets.ENVIRONMENT_URL_TESTING`, or `secrets.ENVIRONMENT_URL` based on the
-          resolved environment (legacy behaviour). Values may reference secrets in the
-          caller workflow, e.g. `production-sg=${{ secrets.ENVIRONMENT_URL_PRODUCTION_SG }}`.
+          for a given branch. If not set, falls back to `vars.ENVIRONMENT_URL_PRODUCTION`,
+          `vars.ENVIRONMENT_URL_TESTING`, or `vars.ENVIRONMENT_URL` (and the equally named
+          secrets as legacy fallback) based on the resolved environment. Values may
+          reference repository variables in the caller workflow, e.g.
+          `production-sg=${{ vars.ENVIRONMENT_URL_PRODUCTION_SG }}`. GitHub does not allow
+          `${{ secrets.* }}` inside `with:`; use `vars.*` or a literal URL instead.
         type: string
         default: ''
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,9 +36,8 @@ on:
           for a given branch. If not set, falls back to `vars.ENVIRONMENT_URL_PRODUCTION`,
           `vars.ENVIRONMENT_URL_TESTING`, or `vars.ENVIRONMENT_URL` (and the equally named
           secrets as legacy fallback) based on the resolved environment. Values may
-          reference repository variables in the caller workflow, e.g.
-          `production-sg=${{ vars.ENVIRONMENT_URL_PRODUCTION_SG }}`. GitHub does not allow
-          `${{ secrets.* }}` inside `with:`; use `vars.*` or a literal URL instead.
+          reference repository variables (`vars.*`) or be plain URLs in the caller
+          workflow. GitHub does not allow `secrets.*` inside the caller's `with:` block.
         type: string
         default: ''
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add [reusable workflow](./.github/workflows/deploy.yml) for GitHub which can be used for deployments.
 - Reusable deploy workflow no longer forces `--branch` on `dep deploy`; the branch
   to deploy is taken from each host's `branch:` config in `deploy.yml`.
+- Reusable deploy workflow now also reads environment URLs from repository
+  variables (`vars.ENVIRONMENT_URL_PRODUCTION` etc.) and falls back to the
+  equally named secret. Per-branch `environment_urls` overrides still win.
 
 ## [0.6.0] - 2021-11-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Reusable deploy workflow now accepts `production_branches`, `testing_branches`,
+  and `environment_urls` inputs so callers can map multiple branches to the same
+  environment tier (e.g. a second production branch deployed to its own host).
+  A branch listed in `production_branches` / `testing_branches` is deployed via
+  its matching Deployer host alias (`dep deploy <branch>`); other branches keep
+  the legacy `stage=staging` label selector.
+
 ### Changed
 - Update `deploy.php` template to support Deployer v7. v6 is no longer supported.  
   To migrate from v6 to v7 see [Deployer's upgrade documentation](https://deployer.org/docs/7.x/UPGRADE#upgrade-from-6x-to-7x).
 - Add [reusable workflow](./.github/workflows/deploy.yml) for GitHub which can be used for deployments.
+- Reusable deploy workflow no longer forces `--branch` on `dep deploy`; the branch
+  to deploy is taken from each host's `branch:` config in `deploy.yml`.
 
 ## [0.6.0] - 2021-11-02
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ How the Deployer host selector is chosen:
 The deployed branch is taken from each host's `branch:` configuration in
 `deploy.yml` — `--branch` is not forced from the workflow side.
 
+Environment URLs are resolved in this order:
+
+1. `environment_urls` input (per-branch override).
+2. Repository variable matching the tier (`vars.ENVIRONMENT_URL_PRODUCTION`,
+   `vars.ENVIRONMENT_URL_TESTING`, or `vars.ENVIRONMENT_URL` for staging).
+3. Secret with the same name (`secrets.ENVIRONMENT_URL_PRODUCTION`, etc.) —
+   legacy fallback.
+
 #### Minimal caller
 
 ```yml
@@ -79,10 +87,14 @@ jobs:
         production
         production-sg
       environment_urls: |
-        production=${{ secrets.ENVIRONMENT_URL_PRODUCTION }}
-        production-sg=${{ secrets.ENVIRONMENT_URL_PRODUCTION_SG }}
+        production-sg=${{ vars.ENVIRONMENT_URL_PRODUCTION_SG }}
     secrets: inherit
 ```
+
+The `production` URL comes from `vars.ENVIRONMENT_URL_PRODUCTION` (or the legacy
+`secrets.ENVIRONMENT_URL_PRODUCTION`) automatically. Only the additional
+`production-sg` URL needs to be passed via `environment_urls`, because secret /
+variable names cannot be looked up dynamically.
 
 Local deploys via `dep deploy stage=production` still target both hosts at
 once, because the `stage` label is shared.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,68 @@ composer require wearerequired/composer-deployer
 * Runs custom commands via `post_rollout_commands` option before the deployment is finished.
 * Provides a [reusable workflow for GitHub](./.github/workflows/deploy.yml) for deployment.
 
+### Reusable deploy workflow
+
+The reusable workflow at [`.github/workflows/deploy.yml`](./.github/workflows/deploy.yml)
+maps the pushed branch to an environment tier (`staging`/`testing`/`production`),
+selects matching Deployer hosts, and reports the deployment back to GitHub and Slack.
+
+How the Deployer host selector is chosen:
+
+- For branches listed in `production_branches` / `testing_branches`, the branch
+  name itself is used as the selector: `dep deploy <branch>`. Deployer 7 matches
+  this against host aliases and label values, so the inventory has to define a
+  matching host (alias `production-sg`, label `branch=production-sg`, etc.).
+- Everything else falls back to the staging tier (`dep deploy stage=staging`),
+  which can match multiple hosts via the `stage` label.
+
+The deployed branch is taken from each host's `branch:` configuration in
+`deploy.yml` — `--branch` is not forced from the workflow side.
+
+#### Minimal caller
+
+```yml
+jobs:
+  deploy:
+    uses: wearerequired/composer-deployer/.github/workflows/deploy.yml@v1
+    secrets: inherit
+```
+
+#### Two production branches targeting separate hosts
+
+`deploy.yml` (host config — branch and stage label per host):
+
+```yml
+hosts:
+  production:
+    branch: production
+    labels:
+      stage: production
+  production-sg:
+    branch: production-sg
+    labels:
+      stage: production
+```
+
+Caller workflow:
+
+```yml
+jobs:
+  deploy:
+    uses: wearerequired/composer-deployer/.github/workflows/deploy.yml@v1
+    with:
+      production_branches: |
+        production
+        production-sg
+      environment_urls: |
+        production=${{ secrets.ENVIRONMENT_URL_PRODUCTION }}
+        production-sg=${{ secrets.ENVIRONMENT_URL_PRODUCTION_SG }}
+    secrets: inherit
+```
+
+Local deploys via `dep deploy stage=production` still target both hosts at
+once, because the `stage` label is shared.
+
 ## Configuration
 
 Next to `deploy.php` you should create a `deploy.yml` file in the project root directory. For the supported syntax see [Deployer's documentation](https://deployer.org/docs/7.x/yaml) or the following example:


### PR DESCRIPTION
## Summary

Replaces the hard-coded `production` / `testing` branch check in the reusable deploy workflow with three configurable inputs:

- `production_branches` / `testing_branches` — newline-separated lists of branches that map to the respective environment tier. For these branches the branch name itself is used as the Deployer selector (`dep deploy <branch>`), so each branch can be routed to a single host without having to share a stage label across multiple production hosts.
- `environment_urls` — optional newline-separated `branch=url` overrides for the deployment URL, used when a single shared per-tier secret is not enough (e.g. two production hosts with different URLs). Values may reference caller secrets, e.g. `production-sg=${{ secrets.ENVIRONMENT_URL_PRODUCTION_SG }}`.

Branches not covered by either list keep the previous staging behaviour (`dep deploy stage=staging`, multi-host via label).

`--branch` is no longer forced on `dep deploy`; each host's `branch:` config in `deploy.yml` is the source of truth for what gets deployed. Locally, `dep deploy stage=production` still targets all production hosts at once.

Defaults preserve backwards compatibility for existing callers (no input changes required for projects using a single `production` and/or `testing` branch).

## Motivation

Enables projects with more than one production branch — e.g. a second production deployment to a separate host — without forking the workflow.

Example caller:

```yml
jobs:
  deploy:
    uses: wearerequired/composer-deployer/.github/workflows/deploy.yml@v1
    with:
      production_branches: |
        production
        production-sg
      environment_urls: |
        production=${{ secrets.ENVIRONMENT_URL_PRODUCTION }}
        production-sg=${{ secrets.ENVIRONMENT_URL_PRODUCTION_SG }}
    secrets: inherit
```

## Test plan

- [ ] Existing single-`production` caller: push to `master` → staging multi-host deploy unchanged.
- [ ] Existing single-`production` caller: push to `production` → only the `production` host deploys (selector is now alias-based instead of `stage=production`; this requires the production host's alias to be `production`, which is the convention already used by our projects).
- [ ] Multi-prod caller: push to `production` → only the `production` host deploys.
- [ ] Multi-prod caller: push to `production-sg` → only the `production-sg` host deploys, picks up its own URL via `environment_urls`.
- [ ] Slack notifications and GitHub deployment status carry the correct environment label and URL for each branch.